### PR TITLE
Payout optimizations

### DIFF
--- a/satchless/order/models.py
+++ b/satchless/order/models.py
@@ -101,7 +101,7 @@ class Order(models.Model):
             for i in xrange(100):
                 token = ''.join(random.sample(
                                 '0123456789abcdefghijklmnopqrstuvwxyz', 32))
-                if not Order.objects.filter(token=token).count():
+                if not Order.objects.filter(token=token).exists():
                     self.token = token
                     break
         return super(Order, self).save(*args, **kwargs)


### PR DESCRIPTION
This PR consists of two optimizations:
- Avoid unnecessary call to `Order.paymentvariant_set.count()` in `Order.paymentvariant`.  This allows us to take advantage of prefetched payment variants in the admin payout view.
- Use `.exists()` instead of `.count()` on Order save (minor optimization)

Assigned @greggarson @dlinder 
