### PR TITLE
Remove mimetype kwarg for JSONResponse

### DIFF
--- a/satchless/util/__init__.py
+++ b/satchless/util/__init__.py
@@ -34,10 +34,9 @@ class JSONResponse(HttpResponse):
             return self.UndercoverDecimal(o)
         raise TypeError()
 
-    def __init__(self, content='', mimetype=None, status=None,
+    def __init__(self, content='', status=None,
                  content_type='application/json'):
         content = json.dumps(content, default=self.handle_decimal)
         return super(JSONResponse, self).__init__(content=content,
-                                                  mimetype=mimetype,
                                                   status=status,
                                                   content_type=content_type)


### PR DESCRIPTION
Min version is 1.6 which already deprecates mimetype